### PR TITLE
Replace global curOfs with the node Field with that purpose

### DIFF
--- a/src/alist.cpp
+++ b/src/alist.cpp
@@ -86,7 +86,7 @@ size_t AList::size() {
 
 void AList::emit(OutputFile* out) {
   for (auto it = iter(); it; it.advance()) {
-    curOfs = it->offset;
+    // curOfs = it->offset;
     if (listCode) it->list();
     it->emit(out);
   }
@@ -138,19 +138,19 @@ void FixupList::initFixups() {
 }
 
 void FixupList::listFixups() {
-  curOfs = fixOfs;
+  std::size_t curOfs = fixOfs;
 
   if (curOfs & 1) {
-    ListByte(0);
+    ListByte(curOfs, 0);
     ++curOfs;
   }
 
   Listing("\n\nFixups:");
-  ListWord(fixups.size());
+  ListWord(curOfs, fixups.size());
   curOfs += 2;
 
   for (size_t fixup : fixups) {
-    ListWord(fixup);
+    ListWord(curOfs, fixup);
     curOfs += 2;
   }
 }

--- a/src/alist.hpp
+++ b/src/alist.hpp
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -45,7 +46,7 @@ struct ANode : TNode {
   // really implemented for each node type yet -- most
   // optimization is done in OptimizeProc() in optimize.cpp.
 
-  size_t offset;  // offset of node in file
+  std::optional<size_t> offset;  // offset of node in file
 };
 
 class AListIter {

--- a/src/anode.hpp
+++ b/src/anode.hpp
@@ -474,7 +474,6 @@ struct ANLineNum : ANOpCode {
 };
 
 extern ANCodeBlk* codeStart;
-extern size_t curOfs;
 extern uint32_t textStart;
 
 #endif

--- a/src/listing.cpp
+++ b/src/listing.cpp
@@ -120,10 +120,11 @@ void ListingImpl(absl::FunctionRef<bool(FILE*)> print_func) {
   }
 }
 
-void ListAsCodeImpl(absl::FunctionRef<bool(FILE*)> print_func) {
+void ListAsCodeImpl(std::size_t offset,
+                    absl::FunctionRef<bool(FILE*)> print_func) {
   if (!listCode || !listFile) return;
 
-  ListOffset();
+  ListOffset(offset);
 
   ListingImpl(print_func);
 }
@@ -169,7 +170,7 @@ void CloseListFile() {
 
 void DeleteListFile() { DeletePath(listName); }
 
-void ListOp(uint8_t theOp) {
+void ListOp(std::size_t offset, uint8_t theOp) {
   OpStr* oPtr;
   std::string_view op;
   std::string scratch;
@@ -178,7 +179,7 @@ void ListOp(uint8_t theOp) {
 
   if (!listCode || !listFile) return;
 
-  ListOffset();
+  ListOffset(offset);
 
   if (!(theOp & OP_LDST)) {
     oPtr = &theOpCodes[(theOp & ~OP_BYTE) / 2];
@@ -246,22 +247,22 @@ void ListOp(uint8_t theOp) {
     Listing("%s", op);
 }
 
-void ListWord(uint16_t w) {
+void ListWord(std::size_t offset, uint16_t w) {
   if (!listCode || !listFile) return;
 
-  ListAsCode("word\t$%x", (SCIUWord)w);
+  ListAsCode(offset, "word\t$%x", (SCIUWord)w);
 }
 
-void ListByte(uint8_t b) {
+void ListByte(std::size_t offset, uint8_t b) {
   if (!listCode || !listFile) return;
 
-  ListAsCode("byte\t$%x", b);
+  ListAsCode(offset, "byte\t$%x", b);
 }
 
-void ListText(std::string_view s) {
+void ListText(std::size_t offset, std::string_view s) {
   std::string line;
 
-  ListAsCode("text");
+  ListAsCode(offset, "text");
 
   line.push_back('"');  // start with a quote
   auto curr_it = s.begin();
@@ -300,10 +301,10 @@ void ListText(std::string_view s) {
   }
 }
 
-void ListOffset() {
+void ListOffset(std::size_t offset) {
   if (!listCode || !listFile) return;
 
-  ListingNoCRLF("\t\t%5x\t", curOfs);
+  ListingNoCRLF("\t\t%5x\t", offset);
 }
 
 void ListSourceLine(int num) {

--- a/src/listing.hpp
+++ b/src/listing.hpp
@@ -14,15 +14,16 @@ void CloseListFile();
 void DeleteListFile();
 template <class... Args>
 void Listing(absl::FormatSpec<Args...> fmt, Args const&... args);
-void ListOp(uint8_t);
+void ListOp(std::size_t offset, uint8_t);
 template <class... Args>
 void ListArg(absl::FormatSpec<Args...> fmt, Args const&... args);
 template <class... Args>
-void ListAsCode(absl::FormatSpec<Args...> fmt, Args const&... args);
-void ListWord(uint16_t);
-void ListByte(uint8_t);
-void ListOffset();
-void ListText(std::string_view);
+void ListAsCode(std::size_t offset, absl::FormatSpec<Args...> fmt,
+                Args const&... args);
+void ListWord(std::size_t offset, uint16_t);
+void ListByte(std::size_t offset, uint8_t);
+void ListOffset(std::size_t offset);
+void ListText(std::size_t offset, std::string_view);
 template <class... Args>
 void ListingNoCRLF(absl::FormatSpec<Args...> fmt, Args const&... args);
 void ListSourceLine(int num);
@@ -34,7 +35,8 @@ extern bool listCode;
 namespace listing_impl {
 
 void ListingImpl(absl::FunctionRef<bool(FILE*)> print_func);
-void ListAsCodeImpl(absl::FunctionRef<bool(FILE*)> print_func);
+void ListAsCodeImpl(std::size_t offset,
+                    absl::FunctionRef<bool(FILE*)> print_func);
 void ListingNoCRLFImpl(absl::FunctionRef<bool(FILE*)> print_func);
 
 }  // namespace listing_impl
@@ -51,9 +53,10 @@ void ListArg(absl::FormatSpec<Args...> fmt, Args const&... args) {
 }
 
 template <class... Args>
-void ListAsCode(absl::FormatSpec<Args...> fmt, Args const&... args) {
+void ListAsCode(std::size_t offset, absl::FormatSpec<Args...> fmt,
+                Args const&... args) {
   listing_impl::ListAsCodeImpl(
-      [&](FILE* fp) { return absl::FPrintF(fp, fmt, args...) != EOF; });
+      offset, [&](FILE* fp) { return absl::FPrintF(fp, fmt, args...) != EOF; });
 }
 
 template <class... Args>


### PR DESCRIPTION
curOfs was used in a few places to track the offset of entities in the output. This fix apparenlty fixes the listing, without affecting the output files (with current tests)