### PR TITLE
Replace token globals with parameter passing

### DIFF
--- a/scic/class.cpp
+++ b/scic/class.cpp
@@ -89,14 +89,14 @@ void DefineClass() {
   // later.
   Symbol* sym = LookupTok();
   if (!sym)
-    sym = gSyms.installClass(gSymStr);
+    sym = gSyms.installClass(gTokenState.symStr());
 
   else if (symType() == S_IDENT || symType() == S_OBJ) {
-    gSyms.del(gSymStr);
-    sym = gSyms.installClass(gSymStr);
+    gSyms.del(gTokenState.symStr());
+    sym = gSyms.installClass(gTokenState.symStr());
 
   } else {
-    Severe("Redefinition of %s.", gSymStr);
+    Severe("Redefinition of %s.", gTokenState.symStr());
     return;
   }
 
@@ -112,7 +112,7 @@ void DefineClass() {
   int superNum = symVal();
   GetKeyword(K_FILE);
   GetString("File name");
-  std::string_view superFile = gSymStr;
+  std::string_view superFile = gTokenState.symStr();
 
   Class* super = FindClass(superNum);
   if (!super) Fatal("Can't find superclass for %s\n", sym->name());
@@ -146,7 +146,8 @@ void DefineClass() {
         break;
 
       default:
-        Severe("Only properties or methods allowed in 'class': %s", gSymStr);
+        Severe("Only properties or methods allowed in 'class': %s",
+               gTokenState.symStr());
     }
     CloseBlock();
   }
@@ -163,7 +164,7 @@ void DefClassItems(Class* theClass, int what) {
   for (Symbol* sym = LookupTok(); !CloseP(symType()); sym = LookupTok()) {
     // Make sure the symbol has been defined as a selector.
     if (!sym || symType() != S_SELECT) {
-      Error("Not a selector: %s", gSymStr);
+      Error("Not a selector: %s", gTokenState.symStr());
       if (PropTag(what)) {
         // Eat the property initialization value.
         GetToken();
@@ -176,7 +177,7 @@ void DefClassItems(Class* theClass, int what) {
     Selector* tn = theClass->findSelectorByNum(sym->val());
     if (tn && PropTag(what) != IsProperty(tn)) {
       Error("Already defined as %s: %s", IsProperty(tn) ? "property" : "method",
-            gSymStr);
+            gTokenState.symStr());
       if (PropTag(what)) {
         GetToken();
         if (!IsNumber()) UnGetTok();

--- a/scic/debug_utils.hpp
+++ b/scic/debug_utils.hpp
@@ -1,8 +1,13 @@
 #ifndef DEBUG_UTILS_H
 #define DEBUG_UTILS_H
 
+#include <array>
+#include <cstdio>
 #include <source_location>
+#include <string_view>
 
+#include "absl/debugging/stacktrace.h"
+#include "absl/debugging/symbolize.h"
 #include "absl/strings/escaping.h"
 #include "absl/strings/str_format.h"
 
@@ -31,5 +36,18 @@ class Escaped {
     sink.Append("\"");
   }
 };
+
+inline void PrintStackTrace() {
+  std::array<void*, 64> stack;
+  int depth = absl::GetStackTrace(stack.data(), stack.size(), 0);
+  std::array<char, 512> symbol_buffer;
+  for (int i = 0; i < depth; ++i) {
+    if (absl::Symbolize(stack[i], symbol_buffer.data(), symbol_buffer.size())) {
+      absl::FPrintF(stderr, "%s\n", symbol_buffer.data());
+    } else {
+      absl::FPrintF(stderr, "??\n");
+    }
+  }
+}
 
 #endif

--- a/scic/error.cpp
+++ b/scic/error.cpp
@@ -28,7 +28,7 @@ void ListingOutput(std::string_view str) {
 
 }  // namespace
 
-void EarlyEnd() { Fatal("Unexpected end of input."); }
+[[noreturn]] void EarlyEnd() { Fatal("Unexpected end of input."); }
 
 static void beep() { putc('\a', stderr); };
 
@@ -43,8 +43,10 @@ void WriteError(std::string_view text) {
   ListingOutput(text);
   ListingOutput("\n");
 
-  if (!CloseP(symType()))
-    GetRest(true);
+  UnGetTok();
+  auto token = GetToken();
+  if (!CloseP(token.type()))
+    (void)GetRest(true);
   else
     UnGetTok();
 
@@ -92,8 +94,10 @@ void WriteSevere(std::string_view text) {
   ListingOutput(text);
   ListingOutput("\n");
 
-  if (!CloseP(symType()))
-    GetRest(true);
+  UnGetTok();
+  auto token = GetToken();
+  if (!CloseP(token.type()))
+    (void)GetRest(true);
   else
     UnGetTok();
 

--- a/scic/error.hpp
+++ b/scic/error.hpp
@@ -4,9 +4,10 @@
 #define ERROR_HPP
 
 #include <string_view>
+
 #include "absl/strings/str_format.h"
 
-void EarlyEnd();
+[[noreturn]] void EarlyEnd();
 
 template <class... Args>
 void Error(absl::FormatSpec<Args...> const&, Args const&... args);

--- a/scic/expr.cpp
+++ b/scic/expr.cpp
@@ -117,7 +117,7 @@ bool Expression(PNode* theNode, bool required) {
       case S_IDENT:
         // Assume that all unknown identifiers are objects,
         // and fall through to object handling.
-        theSym = gSyms.installModule(gSymStr, S_OBJ);
+        theSym = gSyms.installModule(gTokenState.symStr(), S_OBJ);
         theSym->clearAn();
         theSym->setObj(nullptr);
         setSymType(S_OBJ);
@@ -144,7 +144,7 @@ bool Expression(PNode* theNode, bool required) {
         break;
 
       case S_STRING:
-        theNode->newChild(PN_STRING)->val = gText.find(gSymStr);
+        theNode->newChild(PN_STRING)->val = gText.find(gTokenState.symStr());
         isExpr = true;
         break;
 
@@ -155,7 +155,7 @@ bool Expression(PNode* theNode, bool required) {
 
       default:
         if (required)
-          Severe("Expression required: %s", gSymStr);
+          Severe("Expression required: %s", gTokenState.symStr());
         else
           UnGetTok();
         isExpr = false;
@@ -309,13 +309,13 @@ static bool _Expression(PNode* theNode) {
             longjmp(gRecoverBuf, 1);
 
           default:
-            Severe("Expected an expression here: %s", gSymStr);
+            Severe("Expected an expression here: %s", gTokenState.symStr());
             retVal = true;
         }
         break;
 
       default:
-        Severe("Expected an expression here: %s", gSymStr);
+        Severe("Expected an expression here: %s", gTokenState.symStr());
         retVal = true;
     }
   }
@@ -391,7 +391,7 @@ static bool Send(PNode* theNode, Symbol* theSym) {
     if (theSym && theSym->type == S_IDENT) {
       // If the symbol has not been previously defined, define it as
       // an undefined object in the global symbol table.
-      theSym = gSyms.installModule(gSymStr, S_OBJ);
+      theSym = gSyms.installModule(gTokenState.symStr(), S_OBJ);
       theSym->clearAn();
       theSym->setObj(nullptr);
     }
@@ -792,7 +792,7 @@ static bool Variable(PNode* theNode) {
   if (symType() == S_OPEN_BRACKET) return Array(theNode);
 
   if (!IsVar()) {
-    Severe("Variable name expected: %s.", gSymStr);
+    Severe("Variable name expected: %s.", gTokenState.symStr());
     return false;
   }
   pn = theNode->newChild(PNType(symType()));
@@ -808,7 +808,7 @@ static bool Array(PNode* theNode) {
   Symbol* lookupSym = GetSymbol();
   if (lookupSym->type != S_GLOBAL && lookupSym->type != S_LOCAL &&
       lookupSym->type != S_PARM && lookupSym->type != S_TMP) {
-    Severe("Array name expected: %s.", gSymStr);
+    Severe("Array name expected: %s.", gTokenState.symStr());
     return false;
   }
 
@@ -824,7 +824,7 @@ static bool Array(PNode* theNode) {
 
   GetToken();
   if (symType() != (sym_t)']') {
-    Error("Expected closing ']': %s.", gSymStr);
+    Error("Expected closing ']': %s.", gTokenState.symStr());
     return false;
   }
 
@@ -835,7 +835,7 @@ static bool Array(PNode* theNode) {
 static bool Rest(PNode* theNode) {
   LookupTok();
   if (!IsVar() || symType() != S_PARM) {
-    Severe("Variable name expected: %s.", gSymStr);
+    Severe("Variable name expected: %s.", gTokenState.symStr());
     return false;
   }
   theNode->newChild(PN_REST)->val = symVal();

--- a/scic/object.cpp
+++ b/scic/object.cpp
@@ -100,10 +100,10 @@ void DoClass() {
   Symbol* sym = LookupTok();
 
   if (!sym)
-    sym = gSyms.installClass(gSymStr);
+    sym = gSyms.installClass(gTokenState.symStr());
 
   else if (symType() != S_CLASS && symType() != S_OBJ) {
-    Severe("Redefinition of %s.", gSymStr);
+    Severe("Redefinition of %s.", gTokenState.symStr());
     return;
 
   } else {
@@ -134,7 +134,7 @@ void DoClass() {
   // Get the super-class and create this class as an instance of it.
   Symbol* superSym = LookupTok();
   if (!superSym || symType() != S_CLASS) {
-    Severe("%s is not a class.", gSymStr);
+    Severe("%s is not a class.", gTokenState.symStr());
     return;
   }
 
@@ -173,13 +173,13 @@ void Instance() {
   // Get the symbol for the object.
   Symbol* objSym = LookupTok();
   if (!objSym)
-    objSym = gSyms.installLocal(gSymStr, S_OBJ);
+    objSym = gSyms.installLocal(gTokenState.symStr(), S_OBJ);
   else if (symType() == S_IDENT || symType() == S_OBJ) {
     objSym->type = S_OBJ;
     setSymType(S_OBJ);
     if (objSym->obj()) Error("Duplicate instance name: %s", objSym->name());
   } else {
-    Severe("Redefinition of %s.", gSymStr);
+    Severe("Redefinition of %s.", gTokenState.symStr());
     return;
   }
 
@@ -189,7 +189,7 @@ void Instance() {
   // Get the class of which this object is an instance.
   Symbol* sym = LookupTok();
   if (!sym || sym->type != S_CLASS) {
-    Severe("%s is not a class.", gSymStr);
+    Severe("%s is not a class.", gTokenState.symStr());
     return;
   }
   Class* super = (Class*)sym->obj();
@@ -261,7 +261,7 @@ static void InstanceBody(Object* obj) {
         longjmp(gRecoverBuf, 1);
 
       default:
-        Severe("Only property and method definitions allowed: %s.", gSymStr);
+        Severe("Only property and method definitions allowed: %s.", gTokenState.symStr());
         break;
     }
 
@@ -310,12 +310,12 @@ static void Declaration(Object* obj, int type) {
       continue;
     }
 
-    Symbol* sym = gSyms.lookup(gSymStr);
+    Symbol* sym = gSyms.lookup(gTokenState.symStr());
     if (!sym && obj->num != OBJECTNUM) {
       // If the symbol is not currently defined, define it as
       // the next selector number.
-      InstallSelector(gSymStr, NewSelectorNum());
-      sym = gSyms.lookup(gSymStr);
+      InstallSelector(gTokenState.symStr(), NewSelectorNum());
+      sym = gSyms.lookup(gTokenState.symStr());
     }
 
     // If this selector is not in the current class, add it.
@@ -334,7 +334,7 @@ static void Declaration(Object* obj, int type) {
 
     if (sym->type != S_SELECT || (type == T_PROP && !IsProperty(sn)) ||
         (type == T_METHOD && IsProperty(sn))) {
-      Error("Not a %s: %s.", type == T_PROP ? "property" : "method", gSymStr);
+      Error("Not a %s: %s.", type == T_PROP ? "property" : "method", gTokenState.symStr());
       GetToken();
       if (IsNumber()) UnGetTok();
       continue;
@@ -351,7 +351,7 @@ static void Declaration(Object* obj, int type) {
           sn->tag = T_TEXT;
           break;
         default:
-          Fatal("Invalid property type: %s, %d", gSymStr, type);
+          Fatal("Invalid property type: %s, %d", gTokenState.symStr(), type);
           break;
       }
     }

--- a/scic/parse.cpp
+++ b/scic/parse.cpp
@@ -36,7 +36,7 @@ bool Parse() {
     // We require an opening parenthesis at this level.
     // Keep reading until we get one.
     if (!OpenP(symType())) {
-      Error("Opening parenthesis expected: %s", gSymStr);
+      Error("Opening parenthesis expected: %s", gTokenState.symStr());
       while (!OpenP(symType()) && symType() != S_END) NewToken();
       if (symType() == S_END) break;
     }
@@ -111,17 +111,17 @@ bool Parse() {
         break;
 
       case K_UNDEFINED:
-        Severe("Keyword required: %s", gSymStr);
+        Severe("Keyword required: %s", gTokenState.symStr());
         break;
 
       default:
-        Severe("Not a top-level keyword: %s.", gSymStr);
+        Severe("Not a top-level keyword: %s.", gTokenState.symStr());
     }
 
     CloseBlock();
   }
 
-  if (gNestedCondCompile) Error("#if without #endif");
+  if (gTokenState.nestedCondCompile()) Error("#if without #endif");
 
   return !gNumErrors;
 }
@@ -129,15 +129,15 @@ bool Parse() {
 void Include() {
   GetToken();
   if (symType() != S_IDENT && symType() != S_STRING) {
-    Severe("Need a filename: %s", gSymStr);
+    Severe("Need a filename: %s", gTokenState.symStr());
     return;
   }
-  std::string filename = gSymStr;
+  std::string filename = gTokenState.symStr();
   // We need to put this at the right syntactic level, so we GetToken to grab
   // the remaining parent before opening the file.
   GetToken();
   if (symType() != CLOSE_P) {
-    Severe("Expected closing parenthesis: %s", gSymStr);
+    Severe("Expected closing parenthesis: %s", gTokenState.symStr());
     return;
   }
 
@@ -155,7 +155,7 @@ bool CloseBlock() {
   if (symType() == CLOSE_P)
     return true;
   else {
-    Severe("Expected closing parenthesis: %s", gSymStr);
+    Severe("Expected closing parenthesis: %s", gTokenState.symStr());
     return false;
   }
 }

--- a/scic/proc.cpp
+++ b/scic/proc.cpp
@@ -52,7 +52,7 @@ void Procedure() {
   } else {
     // A procedure declaration.
     for (GetToken(); !CloseP(symType()); GetToken()) {
-      if (symType() == S_IDENT) theSym = gSyms.installLocal(gSymStr, S_PROC);
+      if (symType() == S_IDENT) theSym = gSyms.installLocal(gTokenState.symStr(), S_PROC);
       theSym->setVal(UNDEFINED);
     }
     UnGetTok();
@@ -81,14 +81,14 @@ static std::unique_ptr<PNode> _CallDef(sym_t theType) {
   Selector* sn;
 
   GetToken();
-  theProc = gSyms.lookup(gSymStr);
+  theProc = gSyms.lookup(gTokenState.symStr());
   switch (theType) {
     case S_PROC:
       if (!theProc)
-        theProc = gSyms.installModule(gSymStr, theType);
+        theProc = gSyms.installModule(gTokenState.symStr(), theType);
 
       else if (theProc->type != S_PROC || theProc->val() != UNDEFINED) {
-        Severe("%s is already defined.", gSymStr);
+        Severe("%s is already defined.", gTokenState.symStr());
         return 0;
       }
 
@@ -98,7 +98,7 @@ static std::unique_ptr<PNode> _CallDef(sym_t theType) {
     case S_SELECT:
       if (!theProc || !(sn = gCurObj->findSelectorByNum(theProc->val())) ||
           IsProperty(sn)) {
-        Severe("%s is not a method for class %s", gSymStr,
+        Severe("%s is not a method for class %s", gTokenState.symStr(),
                gCurObj->sym->name());
         return 0;
       }
@@ -146,18 +146,18 @@ static int ParameterList() {
       parmOfs += symVal();
       GetToken();
       if (symType() != (sym_t)']') {
-        Error("expecting closing ']': %s.", gSymStr);
+        Error("expecting closing ']': %s.", gTokenState.symStr());
         UnGetTok();
       }
 
     } else if (symType() == S_SELECT) {
-      if (gCurObj && gCurObj->findSelectorByNum(gTokSym.val()))
-        Error("%s is a selector for current object.", gSymStr);
+      if (gCurObj && gCurObj->findSelectorByNum(gTokenState.tokSym().val()))
+        Error("%s is a selector for current object.", gTokenState.symStr());
       else
-        gSyms.installLocal(gSymStr, parmType)->setVal(parmOfs++);
+        gSyms.installLocal(gTokenState.symStr(), parmType)->setVal(parmOfs++);
 
     } else
-      Error("Non-identifier in parameter list: %s", gSymStr);
+      Error("Non-identifier in parameter list: %s", gTokenState.symStr());
   }
 
   if (parmType == S_PARM) AddRest(parmOfs);
@@ -173,8 +173,8 @@ static int ParameterList() {
 static void NewParm(int n, sym_t type) {
   Symbol* theSym;
 
-  if (gSyms.lookup(gSymStr)) Warning("Redefinition of '%s'.", gSymStr);
-  theSym = gSyms.installLocal(gSymStr, type);
+  if (gSyms.lookup(gTokenState.symStr())) Warning("Redefinition of '%s'.", gTokenState.symStr());
+  theSym = gSyms.installLocal(gTokenState.symStr(), type);
   theSym->setVal(n);
 }
 

--- a/scic/selector.cpp
+++ b/scic/selector.cpp
@@ -35,13 +35,13 @@ void InitSelectors() {
   for (Symbol* sym = LookupTok(); !CloseP(symType()); sym = LookupTok()) {
     // Make sure that the symbol is not already defined.
     if (sym && symType() != S_SELECT) {
-      Error("Redefinition of %s.", gSymStr);
+      Error("Redefinition of %s.", gTokenState.symStr());
       GetToken();  // eat selector number
       if (!IsNumber()) UnGetTok();
       continue;
     }
 
-    std::string selStr = gSymStr;
+    std::string selStr = gTokenState.symStr();
 
     GetNumber("Selector number");
     if (!sym)
@@ -107,25 +107,25 @@ Symbol* GetSelector(Symbol* obj) {
 
   // Look up the identifier.  If it is not currently defined, define it as
   // the next selector number.
-  if (!(msgSel = gSyms.lookup(gSymStr))) {
-    InstallSelector(gSymStr, NewSelectorNum());
-    msgSel = gSyms.lookup(gSymStr);
+  if (!(msgSel = gSyms.lookup(gTokenState.symStr()))) {
+    InstallSelector(gTokenState.symStr(), NewSelectorNum());
+    msgSel = gSyms.lookup(gTokenState.symStr());
     if (gConfig->showSelectors)
-      Info("%s is being installed as a selector.", gSymStr);
+      Info("%s is being installed as a selector.", gTokenState.symStr());
   }
-  gTokSym.SaveSymbol(*msgSel);
+  gTokenState.tokSym().SaveSymbol(*msgSel);
 
   // The symbol must be either a variable or a selector.
   if (symType() != S_SELECT && !IsVar()) {
-    Severe("Selector required: %s", gSymStr);
+    Severe("Selector required: %s", gTokenState.symStr());
     return 0;
   }
 
   // Complain if the symbol is a variable, but a selector of the same name
   //	exists.
   if (IsVar() && symType() != S_PROP && symType() != S_SELECT &&
-      gSyms.selectorSymTbl->lookup(gSymStr)) {
-    Error("%s is both a selector and a variable.", gSymStr);
+      gSyms.selectorSymTbl->lookup(gTokenState.symStr())) {
+    Error("%s is both a selector and a variable.", gTokenState.symStr());
     return 0;
   }
 
@@ -148,8 +148,8 @@ Symbol* GetSelector(Symbol* obj) {
       gReceiver = obj->obj();
     }
 
-    if (!gReceiver->findSelectorByNum(gTokSym.val())) {
-      Error("Not a selector for %s: %s", obj->name(), gTokSym.name());
+    if (!gReceiver->findSelectorByNum(gTokenState.tokSym().val())) {
+      Error("Not a selector for %s: %s", obj->name(), gTokenState.tokSym().name());
       return 0;
     }
   }

--- a/scic/symbol.hpp
+++ b/scic/symbol.hpp
@@ -13,6 +13,8 @@
 #include <utility>
 #include <variant>
 
+#include "absl/strings/escaping.h"
+#include "absl/strings/str_format.h"
 #include "scic/define.hpp"
 #include "scic/object.hpp"
 #include "scic/symtypes.hpp"
@@ -80,6 +82,16 @@ class Symbol {
   void setExt(std::unique_ptr<Public> ext);
 
  private:
+  template <class Sink>
+  friend void AbslStringify(Sink& sink, Symbol const& sym) {
+    if (sym.ref_val_.index() == 0) {
+      absl::Format(&sink, "Symbol(type: %d, name: \"%s\", val: %d)", sym.type,
+                   absl::CEscape(sym.name()), sym.val());
+    } else {
+      absl::Format(&sink, "Symbol(type: %d, name: \"%s\")", sym.type,
+                   absl::CEscape(sym.name()));
+    }
+  }
   friend std::ostream& operator<<(std::ostream& os, const Symbol& sym);
 };
 

--- a/scic/toktypes.cpp
+++ b/scic/toktypes.cpp
@@ -35,9 +35,9 @@ Symbol* LookupTok() {
 
   if (symType() == (sym_t)'#') return Immediate();
 
-  if (symType() == S_IDENT && (theSym = gSyms.lookup(gSymStr))) {
-    gTokSym.SaveSymbol(*theSym);
-    gTokSym.clearName();
+  if (symType() == S_IDENT && (theSym = gSyms.lookup(gTokenState.symStr()))) {
+    gTokenState.tokSym().SaveSymbol(*theSym);
+    gTokenState.tokSym().clearName();
   } else
     theSym = 0;
 
@@ -70,8 +70,8 @@ Symbol* GetSymbol() {
   // Get a token that is in the symbol table.
   Symbol* theSym;
   GetToken();
-  if (!(theSym = gSyms.lookup(gSymStr))) {
-    Severe("%s not defined.", gSymStr);
+  if (!(theSym = gSyms.lookup(gTokenState.symStr()))) {
+    Severe("%s not defined.", gTokenState.symStr());
     return nullptr;
   }
 
@@ -93,7 +93,7 @@ bool GetDefineSymbol() {
     Error("Defined symbol expected");
     return false;
   }
-  Symbol* sym = gSyms.lookup(gSymStr);
+  Symbol* sym = gSyms.lookup(gTokenState.symStr());
   if (!sym) return false;
   if (sym->type != S_DEFINE) {
     Error("Define expected");
@@ -104,7 +104,7 @@ bool GetDefineSymbol() {
 
 bool IsIdent() {
   if (symType() != S_IDENT) {
-    Severe("Identifier required: %s", gSymStr);
+    Severe("Identifier required: %s", gTokenState.symStr());
     return false;
   }
 
@@ -114,7 +114,7 @@ bool IsIdent() {
 bool IsUndefinedIdent() {
   if (!IsIdent()) return false;
 
-  if (gSyms.lookup(gSymStr)) Warning("Redefinition of %s.", gSymStr);
+  if (gSyms.lookup(gTokenState.symStr())) Warning("Redefinition of %s.", gTokenState.symStr());
 
   return true;
 }
@@ -166,7 +166,7 @@ bool GetString(std::string_view errStr) {
 
   GetToken();
   if (symType() != S_STRING) {
-    Severe("%s required: %s", errStr, gSymStr);
+    Severe("%s required: %s", errStr, gTokenState.symStr());
     return false;
   }
 
@@ -176,7 +176,7 @@ bool GetString(std::string_view errStr) {
 keyword_t Keyword() {
   Symbol* theSym;
 
-  if (!(theSym = gSyms.lookup(gSymStr)) || theSym->type != S_KEYWORD)
+  if (!(theSym = gSyms.lookup(gTokenState.symStr())) || theSym->type != S_KEYWORD)
     return K_UNDEFINED;
   else {
     setSymType(S_KEYWORD);
@@ -228,7 +228,7 @@ bool IsVar() {
 
     case S_SELECT:
       return gCurObj && gSelectorIsVar &&
-             (sn = gCurObj->findSelectorByNum(gTokSym.val())) &&
+             (sn = gCurObj->findSelectorByNum(gTokenState.tokSym().val())) &&
              sn->tag == T_PROP;
 
     default:
@@ -255,12 +255,12 @@ static Symbol* Immediate() {
 
   GetToken();
   if (symType() == S_IDENT) {
-    if (!(theSym = gSyms.lookup(gSymStr)) || theSym->type != S_SELECT) {
-      Error("Selector required: %s", gSymStr);
+    if (!(theSym = gSyms.lookup(gTokenState.symStr())) || theSym->type != S_SELECT) {
+      Error("Selector required: %s", gTokenState.symStr());
       return 0;
     }
-    gTokSym.SaveSymbol(*theSym);
-    gTokSym.type = S_NUM;
+    gTokenState.tokSym().SaveSymbol(*theSym);
+    gTokenState.tokSym().type = S_NUM;
   }
   return theSym;
 }

--- a/scic/toktypes.hpp
+++ b/scic/toktypes.hpp
@@ -1,26 +1,135 @@
 #ifndef TOKTYPES_HPP
 #define TOKTYPES_HPP
 
+#include <optional>
+#include <stdexcept>
 #include <string_view>
+#include <utility>
+#include <variant>
 
 #include "scic/symbol.hpp"
 #include "scic/symtypes.hpp"
+#include "scic/token.hpp"
 
-Symbol* LookupTok();
-Symbol* GetSymbol();
-bool GetNumber(std::string_view);
-bool GetNumberOrString(std::string_view);
-bool GetString(std::string_view);
-bool GetIdent();
+class ResolvedTokenSlot {
+ public:
+  static ResolvedTokenSlot OfToken(TokenSlot slot) {
+    return ResolvedTokenSlot(std::move(slot));
+  }
+  static ResolvedTokenSlot OfSymbol(Symbol* sym) {
+    return ResolvedTokenSlot(sym);
+  }
+
+  ResolvedTokenSlot() = default;
+  ResolvedTokenSlot(ResolvedTokenSlot const&) = default;
+  ResolvedTokenSlot(ResolvedTokenSlot&&) noexcept = default;
+  ResolvedTokenSlot& operator=(ResolvedTokenSlot const&) = default;
+  ResolvedTokenSlot& operator=(ResolvedTokenSlot&&) noexcept = default;
+
+  bool is_resolved() const { return slot_.index() == 1; }
+
+  TokenSlot const& token() const { return std::get<0>(slot_); }
+  Symbol* symbol() const {
+    return std::holds_alternative<Symbol*>(slot_) ? std::get<1>(slot_)
+                                                  : nullptr;
+  }
+
+  sym_t type() const {
+    switch (slot_.index()) {
+      case 0:
+        return std::get<0>(slot_).type();
+      case 1:
+        return std::get<1>(slot_)->type;
+      default:
+        throw std::runtime_error("Unexpected slot index");
+    }
+  }
+
+  std::string_view name() const {
+    switch (slot_.index()) {
+      case 0:
+        return std::get<0>(slot_).name();
+      case 1:
+        return std::get<1>(slot_)->name();
+      default:
+        throw std::runtime_error("Unexpected slot index");
+    }
+  }
+
+  bool hasVal(int val) const {
+    switch (slot_.index()) {
+      case 0:
+        return std::get<0>(slot_).hasVal(val);
+      case 1:
+        return std::get<1>(slot_)->hasVal(val);
+      default:
+        throw std::runtime_error("Unexpected slot index");
+    }
+  }
+
+  int val() const {
+    switch (slot_.index()) {
+      case 0:
+        return std::get<0>(slot_).val();
+      case 1:
+        return std::get<1>(slot_)->val();
+      default:
+        throw std::runtime_error("Unexpected slot index");
+    }
+  }
+
+ private:
+  explicit ResolvedTokenSlot(TokenSlot slot) : slot_(slot) {}
+  explicit ResolvedTokenSlot(Symbol* sym) : slot_(sym) {}
+  std::variant<TokenSlot, Symbol*> slot_;
+
+  template <class Sink>
+  friend void AbslStringify(Sink& sink, ResolvedTokenSlot const& token) {
+    switch (token.slot_.index()) {
+      case 0:
+        absl::Format(&sink, "ResolvedTokenSlot(token: %v)", token.token());
+        break;
+      case 1:
+        absl::Format(&sink, "ResolvedTokenSlot(symbol: %v)", *token.symbol());
+        break;
+      default:
+        throw std::runtime_error("Unexpected slot index");
+    }
+  }
+};
+
+class RuntimeNumberOrString {
+ public:
+  RuntimeNumberOrString(sym_t type, int val) : type_(type), val_(val) {}
+
+  sym_t type() const { return type_; }
+  int val() const { return val_; }
+
+ private:
+  // Must be S_NUM or S_STRING
+  sym_t type_;
+
+  // The value. If type_ is S_NUM, this is the number. If type_ is S_STRING,
+  // this is the index into the text table.
+  int val_;
+};
+
+[[nodiscard]] ResolvedTokenSlot LookupTok();
+[[nodiscard]] ResolvedTokenSlot GetSymbol();
+[[nodiscard]] std::optional<int> GetNumber(std::string_view);
+[[nodiscard]] std::optional<RuntimeNumberOrString> GetNumberOrString(
+    std::string_view);
+[[nodiscard]] std::optional<TokenSlot> GetString(std::string_view);
+[[nodiscard]] std::optional<TokenSlot> GetIdent();
 bool GetDefineSymbol();
-bool IsIdent();
-bool IsUndefinedIdent();
-keyword_t Keyword();
+bool IsIdent(TokenSlot const& token);
+bool IsUndefinedIdent(TokenSlot const& token);
+keyword_t Keyword(TokenSlot const& token);
 void GetKeyword(keyword_t);
-bool IsVar();
-bool IsProc();
-bool IsObj();
-bool IsNumber();
+bool IsVar(ResolvedTokenSlot const& token);
+bool IsProc(ResolvedTokenSlot const& token);
+bool IsObj(ResolvedTokenSlot const& token);
+bool IsNumber(TokenSlot const& token);
 
 extern int gSelectorIsVar;
 

--- a/scic/update.cpp
+++ b/scic/update.cpp
@@ -112,15 +112,15 @@ void WritePropOffsets() {
   out.Write(resHdr, sizeof resHdr);
 
   while (NewToken()) {
-    theSym = gSyms.lookup(gSymStr);
+    theSym = gSyms.lookup(gTokenState.symStr());
     if (theSym->type != S_CLASS) {
-      Error("Not a class: %s", gSymStr);
+      Error("Not a class: %s", gTokenState.symStr());
       GetToken();
       continue;
     }
     cp = theSym->obj();
-    if (!LookupTok() || !(sel = cp->findSelectorByNum(gTokSym.val()))) {
-      Error("Not a selector for class %s: %s", cp->sym->name(), gSymStr);
+    if (!LookupTok() || !(sel = cp->findSelectorByNum(gTokenState.tokSym().val()))) {
+      Error("Not a selector for class %s: %s", cp->sym->name(), gTokenState.symStr());
       continue;
     }
 


### PR DESCRIPTION
Previously, functions like NewToken() returned the token result via a global variable, making it hard to trace dataflow through the program. This changes functions to no longer depend on these global variables for state passing.