### PR TITLE
Add the ListTree parser

### DIFF
--- a/scic/parsers/list_tree/BUILD.bazel
+++ b/scic/parsers/list_tree/BUILD.bazel
@@ -7,6 +7,7 @@ cc_library(
     hdrs = ["ast.hpp"],
     deps = [
         "//scic/tokenizer:token",
+        "@abseil-cpp//absl/strings:str_format",
         "@abseil-cpp//absl/types:span",
     ],
 )
@@ -19,8 +20,20 @@ cc_library(
         ":ast",
         "//scic/tokenizer:token",
         "//scic/tokenizer:token_stream",
+        "//util/status:status_macros",
         "@abseil-cpp//absl/container:btree",
         "@abseil-cpp//absl/status:statusor",
         "@abseil-cpp//absl/types:span",
+    ],
+)
+
+cc_binary(
+    name = "parser_test_tool",
+    srcs = ["parser_test_tool.cpp"],
+    deps = [
+        ":parser",
+        "//scic/tokenizer:token",
+        "//scic/tokenizer:token_readers",
+        "@argparse",
     ],
 )

--- a/scic/parsers/list_tree/BUILD.bazel
+++ b/scic/parsers/list_tree/BUILD.bazel
@@ -10,3 +10,17 @@ cc_library(
         "@abseil-cpp//absl/types:span",
     ],
 )
+
+cc_library(
+    name = "parser",
+    srcs = ["parser.cpp"],
+    hdrs = ["parser.hpp"],
+    deps = [
+        ":ast",
+        "//scic/tokenizer:token",
+        "//scic/tokenizer:token_stream",
+        "@abseil-cpp//absl/container:btree",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/types:span",
+    ],
+)

--- a/scic/parsers/list_tree/BUILD.bazel
+++ b/scic/parsers/list_tree/BUILD.bazel
@@ -1,0 +1,12 @@
+# This is a parser for a list of trees, like an S-expression. This takes the
+# raw S-expression like language of SCI script, and creates a basic parse tree for it.
+
+cc_library(
+    name = "ast",
+    srcs = ["ast.cpp"],
+    hdrs = ["ast.hpp"],
+    deps = [
+        "//scic/tokenizer:token",
+        "@abseil-cpp//absl/types:span",
+    ],
+)

--- a/scic/parsers/list_tree/ast.cpp
+++ b/scic/parsers/list_tree/ast.cpp
@@ -1,0 +1,56 @@
+#include "scic/parsers/list_tree/ast.hpp"
+
+#include <memory>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "absl/types/span.h"
+#include "scic/tokenizer/token.hpp"
+
+namespace parser::list_tree {
+
+using ::tokenizer::Token;
+
+struct TokenExpr::PImpl {
+  Token token;
+};
+
+TokenExpr::TokenExpr(Token token)
+    : pimpl_(std::make_shared<PImpl>(PImpl{
+          .token = std::move(token),
+      })) {}
+
+Token const& TokenExpr::token() const { return pimpl_->token; }
+
+struct ListExpr::PImpl {
+  std::vector<Expr> elements;
+  Token start_paren;
+  Token end_paren;
+};
+
+ListExpr::ListExpr(Token start_paren, Token end_paren,
+                   std::vector<Expr> elements)
+    : pimpl_(std::make_shared<PImpl>(PImpl{
+          .elements = std::move(elements),
+      })) {}
+
+Token const& ListExpr::start_paren() const { return pimpl_->start_paren; }
+Token const& ListExpr::end_paren() const { return pimpl_->end_paren; }
+
+absl::Span<Expr const> ListExpr::elements() const {
+  return absl::MakeConstSpan(pimpl_->elements);
+}
+
+Expr::Expr(TokenExpr token_expr) : expr_(std::move(token_expr)) {}
+Expr::Expr(ListExpr list_expr) : expr_(std::move(list_expr)) {}
+
+TokenExpr const* Expr::AsTokenExpr() const {
+  return std::get_if<TokenExpr>(&expr_);
+}
+
+ListExpr const* Expr::AsListExpr() const {
+  return std::get_if<ListExpr>(&expr_);
+}
+
+}  // namespace parser::list_tree

--- a/scic/parsers/list_tree/ast.hpp
+++ b/scic/parsers/list_tree/ast.hpp
@@ -1,0 +1,55 @@
+#ifndef PARSER_LIST_TREE_AST_HPP
+#define PARSER_LIST_TREE_AST_HPP
+
+#include <memory>
+#include <variant>
+#include <vector>
+
+#include "absl/types/span.h"
+#include "scic/tokenizer/token.hpp"
+
+namespace parser::list_tree {
+
+class Expr;
+
+class TokenExpr {
+ public:
+  TokenExpr(tokenizer::Token token);
+
+  tokenizer::Token const& token() const;
+
+ private:
+  struct PImpl;
+  std::shared_ptr<PImpl> pimpl_;
+};
+
+class ListExpr {
+ public:
+  ListExpr(tokenizer::Token start_paren, tokenizer::Token end_paren,
+           std::vector<Expr> elements);
+
+  tokenizer::Token const& start_paren() const;
+  tokenizer::Token const& end_paren() const;
+
+  absl::Span<Expr const> elements() const;
+
+ private:
+  struct PImpl;
+  std::shared_ptr<PImpl> pimpl_;
+};
+
+class Expr {
+ public:
+  explicit Expr(TokenExpr token_expr);
+  explicit Expr(ListExpr list_expr);
+
+  TokenExpr const* AsTokenExpr() const;
+  ListExpr const* AsListExpr() const;
+
+ private:
+  std::variant<TokenExpr, ListExpr> expr_;
+};
+
+}  // namespace parser::list_tree
+
+#endif

--- a/scic/parsers/list_tree/ast.hpp
+++ b/scic/parsers/list_tree/ast.hpp
@@ -18,6 +18,8 @@ class TokenExpr {
 
   tokenizer::Token const& token() const;
 
+  void WriteTokens(std::vector<tokenizer::Token>* tokens) const;
+
  private:
   struct PImpl;
   std::shared_ptr<PImpl> pimpl_;
@@ -33,6 +35,8 @@ class ListExpr {
 
   absl::Span<Expr const> elements() const;
 
+  void WriteTokens(std::vector<tokenizer::Token>* tokens) const;
+
  private:
   struct PImpl;
   std::shared_ptr<PImpl> pimpl_;
@@ -45,6 +49,9 @@ class Expr {
 
   TokenExpr const* AsTokenExpr() const;
   ListExpr const* AsListExpr() const;
+
+  // Write these tokens back in order to the given vector.
+  void WriteTokens(std::vector<tokenizer::Token>* tokens) const;
 
  private:
   std::variant<TokenExpr, ListExpr> expr_;

--- a/scic/parsers/list_tree/parser.cpp
+++ b/scic/parsers/list_tree/parser.cpp
@@ -1,0 +1,476 @@
+#include "scic/parsers/list_tree/parser.hpp"
+
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "absl/container/btree_map.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "scic/parsers/list_tree/ast.hpp"
+#include "scic/tokenizer/token.hpp"
+#include "scic/tokenizer/token_stream.hpp"
+#include "util/status/status_macros.hpp"
+
+namespace parser::list_tree {
+namespace {
+using ::tokenizer::Token;
+using ::tokenizer::TokenStream;
+
+// Returns the name of the expression, if it is a token identifier with no
+// trailer.
+std::optional<std::string_view> GetExprPlainIdent(Expr const& expr) {
+  auto* token_expr = expr.AsTokenExpr();
+  if (!token_expr) {
+    return std::nullopt;
+  }
+  auto* ident = token_expr->token().AsIdent();
+  if (!ident || ident->trailer != Token::Ident::None) {
+    return std::nullopt;
+  }
+  return ident->name;
+}
+
+class Parser {
+ public:
+  Parser(
+      std::unique_ptr<TokenStream> token_stream,
+      absl::btree_map<std::string, std::vector<Token>> const& initial_defines,
+      IncludeContext const* include_context)
+      : token_stream_(std::move(token_stream)),
+        curr_defines_(std::move(initial_defines)),
+        include_context_(include_context) {
+    for (auto const& [key, value] : initial_defines) {
+      curr_defines_.insert_or_assign(key, value);
+    }
+  }
+
+  absl::StatusOr<std::optional<Token>> GetNextToken() {
+    if (!pushed_tokens_.empty()) {
+      auto token = std::move(pushed_tokens_.back());
+      pushed_tokens_.pop_back();
+      return token;
+    }
+    while (true) {
+      auto token = token_stream_->NextToken();
+      if (!token) {
+        if (!preproc_stack_.empty()) {
+          return absl::InvalidArgumentError(
+              "Unexpected end of input when "
+              "preprocessor directive still active.");
+        }
+        return std::nullopt;
+      }
+
+      auto* preproc = token->AsPreProcessor();
+      if (preproc) {
+        RETURN_IF_ERROR(HandlePreProcessorToken(*preproc));
+        continue;
+      }
+
+      if (!preproc_stack_.empty() && !preproc_stack_.back().producing_tokens) {
+        // Skip tokens until the next preprocessor directive.
+        continue;
+      }
+
+      auto* ident = token->AsIdent();
+      if (ident && ident->trailer == Token::Ident::None) {
+        // It's possible this could be defined. If so, we need to replace it
+        // in the stream with the defined tokens.
+        auto define = curr_defines_.find(ident->name);
+        if (define != curr_defines_.end()) {
+          token_stream_->PushTokens(define->second);
+          continue;
+        }
+      }
+
+      return token;
+    }
+  }
+
+  absl::Status HandlePreProcessorToken(Token::PreProcessor const& preproc) {
+    enum class StackChange {
+      // Push a new frame
+      Push,
+
+      // Go to next clause of current frame
+      Next,
+
+      // Pop the current frame
+      Pop,
+    };
+
+    enum class Condition {
+      // True if an identifier is defined.
+      Def,
+
+      // True if an identifier is not defined.
+      NotDef,
+
+      // True if a static expression is nonzero (after define resolution).
+      Cond,
+
+      // Always taken, if possible.
+      Always,
+    };
+
+    StackChange stack_change;
+    Condition condition;
+    switch (preproc.type) {
+      // Cases that start a new preprocessor frame.
+      case tokenizer::Token::PPT_IFDEF:
+        stack_change = StackChange::Push;
+        condition = Condition::Def;
+        break;
+      case tokenizer::Token::PPT_IFNDEF:
+        stack_change = StackChange::Push;
+        condition = Condition::NotDef;
+        break;
+      case tokenizer::Token::PPT_IF:
+        stack_change = StackChange::Push;
+        condition = Condition::Cond;
+        break;
+
+        // Cases that keep a current preprocessor frame.
+      case tokenizer::Token::PPT_ELIFDEF:
+        stack_change = StackChange::Next;
+        condition = Condition::Def;
+        break;
+      case tokenizer::Token::PPT_ELIFNDEF:
+        stack_change = StackChange::Next;
+        condition = Condition::NotDef;
+        break;
+      case tokenizer::Token::PPT_ELIF:
+        stack_change = StackChange::Next;
+        condition = Condition::Cond;
+        break;
+      case tokenizer::Token::PPT_ELSE:
+        stack_change = StackChange::Next;
+        condition = Condition::Always;
+        break;
+
+        // Cases that pop a preprocessing frame.
+      case tokenizer::Token::PPT_ENDIF:
+        stack_change = StackChange::Pop;
+        condition = Condition::Always;
+        break;
+    }
+
+    switch (stack_change) {
+      case StackChange::Push:
+        // If we're currently not generating tokens in the current frame, we
+        // need to push, but disable the frame.
+        if (!preproc_stack_.empty() &&
+            !preproc_stack_.back().producing_tokens) {
+          preproc_stack_.push_back({
+              .producing_tokens = false,
+              // Pretend a previous case was triggered, so no clauses are
+              // ever triggered.
+              .case_triggered = true,
+          });
+        } else {
+          preproc_stack_.push_back({
+              .producing_tokens = false,
+              .case_triggered = false,
+          });
+        }
+        break;
+      case StackChange::Next:
+        // If we were producing tokens in the previous clause, we don't want
+        // to now.
+        if (preproc_stack_.empty()) {
+          return absl::InvalidArgumentError(
+              "Unexpected #elif or #else without #if.");
+        }
+        preproc_stack_.back().producing_tokens = false;
+        break;
+      case StackChange::Pop:
+        // If we popped, the previous frame should already have the state
+        // needed. Just return to skip any conditionals.
+        preproc_stack_.pop_back();
+        return absl::OkStatus();
+    }
+
+    // If we're here, we should have at least one frame on the stack, with
+    // its producing_tokens set to false.
+
+    if (preproc_stack_.back().case_triggered) {
+      // We've already triggered a case in this frame, so we should not
+      // do any further checks.
+      return absl::OkStatus();
+    }
+
+    // Check the conditional to see if we should produce tokens for the next
+    // clause.
+
+    bool condition_result;
+    switch (condition) {
+      case Condition::Def: {
+        ASSIGN_OR_RETURN(condition_result, IsDef(preproc.lineTokens));
+        break;
+      }
+      case Condition::NotDef: {
+        ASSIGN_OR_RETURN(auto is_def, IsDef(preproc.lineTokens));
+        condition_result = !is_def;
+        break;
+      }
+      case Condition::Cond: {
+        ASSIGN_OR_RETURN(condition_result, IsTrue(preproc.lineTokens));
+        break;
+      }
+      case Condition::Always:
+        condition_result = true;
+        break;
+    }
+
+    if (!condition_result) {
+      preproc_stack_.back().producing_tokens = true;
+      preproc_stack_.back().case_triggered = true;
+    }
+
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<bool> IsDef(absl::Span<Token const> tokens) {
+    if (tokens.size() != 1) {
+      // We need exactly one token.
+      return absl::InvalidArgumentError(
+          "Expected a single identifier for preprocessor condition.");
+    }
+
+    auto* ident = tokens[0].AsIdent();
+
+    if (!ident) {
+      return curr_defines_.contains(ident->name);
+    }
+
+    return absl::InvalidArgumentError(
+        "Expected a single identifier for preprocessor condition.");
+  }
+
+  absl::StatusOr<bool> IsTrue(absl::Span<Token const> tokens) {
+    if (tokens.size() != 1) {
+      // We need exactly one token.
+      return absl::InvalidArgumentError(
+          "Expected a single identifier for preprocessor condition.");
+    }
+
+    auto* token = &tokens[0];
+    std::set<std::string_view> previous_defs;
+    while (true) {
+      auto* number = token->AsNumber();
+      if (number) {
+        return number->value != 0;
+      }
+
+      auto* ident = token->AsIdent();
+      if (ident) {
+        if (previous_defs.contains(ident->name)) {
+          return absl::InvalidArgumentError(
+              "Infinite loop in preprocessor condition.");
+        }
+        previous_defs.insert(ident->name);
+
+        auto define = curr_defines_.find(ident->name);
+        if (define == curr_defines_.end()) {
+          return absl::InvalidArgumentError(
+              "Undefined identifier in preprocessor condition.");
+        }
+
+        if (define->second.size() != 1) {
+          return absl::InvalidArgumentError(
+              "Expected a single token for preprocessor condition.");
+        }
+
+        token = &define->second[0];
+        continue;
+      }
+    }
+  }
+
+  absl::StatusOr<std::optional<Expr>> ParseExpr() {
+    ASSIGN_OR_RETURN(auto token, GetNextToken());
+    if (!token) {
+      return std::nullopt;
+    }
+
+    auto* punct = token->AsPunct();
+    if (punct && punct->type == Token::PCT_LPAREN) {
+      ASSIGN_OR_RETURN(auto list_expr, ParseList(std::move(token).value()));
+      return Expr(std::move(list_expr));
+    }
+
+    return Expr(TokenExpr(std::move(token).value()));
+  }
+
+  absl::StatusOr<ListExpr> ParseList(Token start_paren) {
+    // We've already read the opening parenthesis.
+    std::vector<Expr> elements;
+
+    while (true) {
+      ASSIGN_OR_RETURN(auto next_token, GetNextToken());
+      if (!next_token) {
+        return absl::InvalidArgumentError("Unexpected end of list.");
+      }
+
+      auto* punct = next_token->AsPunct();
+      if (punct && punct->type == Token::PCT_RPAREN) {
+        return ListExpr(std::move(start_paren), std::move(next_token).value(),
+                        std::move(elements));
+      }
+
+      pushed_tokens_.push_back(std::move(next_token).value());
+
+      ASSIGN_OR_RETURN(auto next_expr, ParseExpr());
+      if (!next_expr) {
+        return absl::InvalidArgumentError("Unexpected end of list.");
+      }
+    }
+  }
+
+  absl::StatusOr<std::optional<Expr>> TopLevelExpr() {
+    while (true) {
+      ASSIGN_OR_RETURN(auto expr, ParseExpr());
+      if (!expr) {
+        return std::nullopt;
+      }
+
+      // We handle two kinds of top-level expressions: An include, or a define.
+      auto* list_expr = expr->AsListExpr();
+      if (!list_expr) {
+        // This isn't a list.
+        return expr;
+      }
+
+      auto const& elements = list_expr->elements();
+
+      if (elements.empty()) {
+        // This list is empty.
+        return expr;
+      }
+
+      auto name = GetExprPlainIdent(elements[0]);
+      if (!name) {
+        return expr;
+      }
+      if (*name == "include") {
+        RETURN_IF_ERROR(HandleInclude(elements.subspan(1)));
+        continue;
+      } else if (*name == "define") {
+        RETURN_IF_ERROR(HandleDefine(elements.subspan(1)));
+        continue;
+      } else {
+        return expr;
+      }
+    }
+  }
+
+  absl::Status HandleDefine(absl::Span<Expr const> rest_elements) {
+    if (rest_elements.size() < 2) {
+      return absl::InvalidArgumentError(
+          "A define needs a symbol and a sequence of values.");
+    }
+
+    auto name = GetExprPlainIdent(rest_elements[0]);
+    if (!name) {
+      return absl::InvalidArgumentError(
+          "First element of define must be an identifier.");
+    }
+
+    auto values = rest_elements.subspan(1);
+
+    std::vector<Token> value_tokens;
+
+    for (auto const& value_expr : values) {
+      value_expr.WriteTokens(&value_tokens);
+    }
+
+    curr_defines_.insert_or_assign(*name, std::move(value_tokens));
+    return absl::OkStatus();
+  }
+
+  absl::Status HandleInclude(absl::Span<Expr const> rest_elements) {
+    // This could cause preprocessor desyncs, if we include a file that
+    // has misformatted preprocessor directives. If we want to handle this,
+    // we will have to track the source of each define clause.
+    if (rest_elements.size() != 1) {
+      return absl::InvalidArgumentError("Include requires a single argument.");
+    }
+
+    // An include argument can be a string or an identifier.
+    auto* token_expr = rest_elements[0].AsTokenExpr();
+    if (!token_expr) {
+      return absl::InvalidArgumentError(
+          "Include argument must be either a string or symbol.");
+    }
+
+    std::string_view include_path;
+    if (auto* string = token_expr->token().AsString()) {
+      include_path = string->decodedString;
+    } else if (auto* ident = token_expr->token().AsIdent()) {
+      include_path = ident->name;
+    } else {
+      return absl::InvalidArgumentError(
+          "Include argument must be either a string or symbol.");
+    }
+    ASSIGN_OR_RETURN(auto tokens,
+                     include_context_->LoadTokensFromInclude(include_path));
+    token_stream_->PushTokens(std::move(tokens));
+
+    return absl::OkStatus();
+  }
+
+ private:
+  // The state of the current preprocessor frame. There is one frame for
+  // each layer of context active during the parse.
+  struct PreProcessorFrame {
+    // Iff true, tokens that we are seeing from the token stream are being
+    // produced during parsing.
+    bool producing_tokens;
+
+    // If true, then a previous preprocessor directive at this frame has
+    // been triggered, such as an #if clause. This allows us to track if
+    // we should observe future #else or #elif clauses.
+    bool case_triggered;
+  };
+
+  // The stack of preprocessor frames. The top of the stack is the back end
+  // of the vector. If empty, we will always be producing tokens.
+  std::vector<PreProcessorFrame> preproc_stack_;
+
+  // Tokens that have been pushed to be returned again on the next call to
+  // GetNextToken().
+  std::vector<Token> pushed_tokens_;
+  std::unique_ptr<TokenStream> token_stream_;
+  absl::btree_map<std::string, std::vector<Token>> curr_defines_;
+  IncludeContext const* include_context_;
+};
+
+}  // namespace
+
+absl::StatusOr<std::vector<Expr>> ParseListTree(
+    std::vector<tokenizer::Token> initial_tokens,
+    IncludeContext const* include_context,
+    absl::btree_map<std::string, std::vector<tokenizer::Token>> const&
+        initial_defines) {
+  auto token_stream = std::make_unique<TokenStream>();
+  token_stream->PushTokens(std::move(initial_tokens));
+
+  Parser parser(std::move(token_stream), initial_defines, include_context);
+
+  std::vector<Expr> exprs;
+
+  while (true) {
+    ASSIGN_OR_RETURN(auto expr, parser.TopLevelExpr());
+    if (!expr) {
+      return exprs;
+    }
+    exprs.push_back(std::move(*expr));
+  }
+}
+}  // namespace parser::list_tree

--- a/scic/parsers/list_tree/parser.cpp
+++ b/scic/parsers/list_tree/parser.cpp
@@ -330,6 +330,7 @@ class Parser {
       if (!next_expr) {
         return absl::InvalidArgumentError("Unexpected end of list.");
       }
+      elements.push_back(std::move(next_expr).value());
     }
   }
 

--- a/scic/parsers/list_tree/parser.hpp
+++ b/scic/parsers/list_tree/parser.hpp
@@ -1,0 +1,31 @@
+#ifndef PARSER_LIST_TREE_PARSER_HPP
+#define PARSER_LIST_TREE_PARSER_HPP
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "absl/container/btree_map.h"
+#include "absl/status/statusor.h"
+#include "scic/parsers/list_tree/ast.hpp"
+#include "scic/tokenizer/token.hpp"
+
+namespace parser::list_tree {
+
+class IncludeContext {
+ public:
+  virtual ~IncludeContext() = default;
+
+  virtual absl::StatusOr<std::vector<tokenizer::Token>> LoadTokensFromInclude(
+      std::string_view path) const = 0;
+};
+
+absl::StatusOr<std::vector<Expr>> ParseListTree(
+    std::vector<tokenizer::Token> initial_tokens,
+    IncludeContext const* include_context,
+    absl::btree_map<std::string, std::vector<tokenizer::Token>> const&
+        initial_defines);
+
+}  // namespace parser::list_tree
+
+#endif

--- a/scic/parsers/list_tree/parser_test_tool.cpp
+++ b/scic/parsers/list_tree/parser_test_tool.cpp
@@ -1,0 +1,122 @@
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <ios>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "absl/container/btree_map.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "argparse/argparse.hpp"
+#include "scic/parsers/list_tree/parser.hpp"
+#include "scic/tokenizer/text_contents.hpp"
+#include "scic/tokenizer/token.hpp"
+#include "scic/tokenizer/token_readers.hpp"
+#include "util/status/status_macros.hpp"
+
+namespace {
+
+using ::tokenizer::TextRange;
+using ::tokenizer::Token;
+
+absl::StatusOr<std::vector<Token>> TokenizeFile(
+    std::filesystem::path const& path) {
+  std::ifstream file;
+  file.open(path, std::ios::in | std::ios::binary);
+  if (!file.good()) {
+    return absl::NotFoundError("Could not open file");
+  }
+
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+
+  return tokenizer::TokenizeText(
+      TextRange::WithFilename(path.string(), buffer.str()));
+}
+
+class ToolIncludeContext : public parser::list_tree::IncludeContext {
+ public:
+  ToolIncludeContext(std::vector<std::filesystem::path> include_paths)
+      : include_paths_(std::move(include_paths)) {}
+
+  absl::StatusOr<std::vector<Token>> LoadTokensFromInclude(
+      std::string_view path) const override {
+    std::ifstream file;
+    for (auto const& include_path : include_paths_) {
+      auto result = TokenizeFile(include_path / path);
+      if (result.ok()) {
+        return std::move(result).value();
+      }
+
+      if (!absl::IsNotFound(result.status())) {
+        return result.status();
+      }
+    }
+
+    return absl::NotFoundError(
+        absl::StrFormat("Could not find include file: %s", path));
+  }
+
+ private:
+  std::vector<std::filesystem::path> include_paths_;
+};
+
+absl::StatusOr<int> RunMain(int argc, char** argv) {
+  argparse::ArgumentParser program("parser_test_tool", "Test tool for parser");
+  program.add_argument("-I", "--include")
+      .help("Add an include path")
+      .default_value(std::vector<std::string>())
+      .nargs(1);
+  program.add_argument("files")
+      .default_value(std::vector<std::string>())
+      .remaining();
+
+  try {
+    program.parse_args(argc, argv);
+  } catch (const std::exception& err) {
+    std::cerr << err.what() << std::endl;
+    std::cerr << program;
+    return 1;
+  }
+
+  std::vector<std::filesystem::path> include_paths;
+
+  for (auto include_path_str : program.get<std::vector<std::string>>("-I")) {
+    include_paths.push_back(std::filesystem::path(include_path_str));
+  }
+
+  auto files = program.get<std::vector<std::string>>("files");
+
+  ToolIncludeContext include_context(std::move(include_paths));
+
+  for (auto const& file : files) {
+    ASSIGN_OR_RETURN(auto tokens, TokenizeFile(file));
+    ASSIGN_OR_RETURN(auto parsed, parser::list_tree::ParseListTree(
+                                      tokens, &include_context, {}));
+
+    // Print the parsed tree.
+    absl::PrintF("Parsed %s:\n", file);
+    for (auto const& expr : parsed) {
+      absl::PrintF("  %v\n", expr);
+    }
+  }
+  return 0;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  auto result = RunMain(argc, argv);
+  if (!result.ok()) {
+    std::cerr << "Error: " << result.status() << std::endl;
+    return 1;
+  }
+
+  return result.value();
+}

--- a/scic/tokenizer/BUILD.bazel
+++ b/scic/tokenizer/BUILD.bazel
@@ -8,6 +8,7 @@ cc_library(
     hdrs = ["token.hpp"],
     deps = [
         ":text_contents",
+        "@abseil-cpp//absl/strings:str_format",
     ],
 )
 
@@ -25,7 +26,6 @@ cc_library(
     name = "token_readers",
     srcs = ["token_readers.cpp"],
     hdrs = ["token_readers.hpp"],
-    visibility = ["//visibility:private"],
     deps = [
         ":char_stream",
         ":token",
@@ -73,5 +73,14 @@ cc_test(
         ":char_stream",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "token_stream",
+    srcs = ["token_stream.cpp"],
+    hdrs = ["token_stream.hpp"],
+    deps = [
+        "@abseil-cpp//absl/strings",
     ],
 )

--- a/scic/tokenizer/char_stream.hpp
+++ b/scic/tokenizer/char_stream.hpp
@@ -35,6 +35,8 @@ class CharStream {
 
   bool TryConsumePrefix(std::string_view prefix);
 
+  TextRange GetText() const { return range_; }
+
  private:
   struct LineSpan {
     std::size_t start;

--- a/scic/tokenizer/token.hpp
+++ b/scic/tokenizer/token.hpp
@@ -5,6 +5,7 @@
 #include <variant>
 #include <vector>
 
+#include "absl/strings/str_format.h"
 #include "scic/tokenizer/text_contents.hpp"
 
 namespace tokenizer {
@@ -100,6 +101,23 @@ class Token {
  private:
   TextRange text_range_;
   TokenValue value_;
+
+  template <class Sink>
+  friend void AbslStringify(Sink& sink, Token const& token) {
+    if (auto* ident = token.AsIdent()) {
+      absl::Format(&sink, "Ident(%v)", ident->name);
+    } else if (auto* string = token.AsString()) {
+      absl::Format(&sink, "String(%v)", string->decodedString);
+    } else if (auto* number = token.AsNumber()) {
+      absl::Format(&sink, "Number(%d)", number->value);
+    } else if (auto* punct = token.AsPunct()) {
+      absl::Format(&sink, "Punct(%d)", punct->type);
+    } else if (auto* preproc = token.AsPreProcessor()) {
+      absl::Format(&sink, "PreProc(%d)", preproc->type);
+    } else {
+      absl::Format(&sink, "Unknown");
+    }
+  }
 };
 
 }  // namespace tokenizer

--- a/scic/tokenizer/token.hpp
+++ b/scic/tokenizer/token.hpp
@@ -89,6 +89,14 @@ class Token {
   TextRange const& text_range() const { return text_range_; }
   TokenValue const& value() const { return value_; }
 
+  Ident const* AsIdent() const { return std::get_if<Ident>(&value_); }
+  Punct const* AsPunct() const { return std::get_if<Punct>(&value_); }
+  Number const* AsNumber() const { return std::get_if<Number>(&value_); }
+  String const* AsString() const { return std::get_if<String>(&value_); }
+  PreProcessor const* AsPreProcessor() const {
+    return std::get_if<PreProcessor>(&value_);
+  }
+
  private:
   TextRange text_range_;
   TokenValue value_;

--- a/scic/tokenizer/token_readers.cpp
+++ b/scic/tokenizer/token_readers.cpp
@@ -354,7 +354,7 @@ absl::StatusOr<Token::TokenValue> ReadToken(CharStream& stream) {
   if (IsTok(*stream)) {
     // This is equivalent to our Punct struct.
     return Token::Punct{
-        .type = CharToPunctType(*stream),
+        .type = CharToPunctType(*stream++),
     };
   }
 
@@ -434,7 +434,6 @@ absl::StatusOr<std::optional<Token>> NextToken(CharStream& stream) {
 
   auto token_start = stream;
   ASSIGN_OR_RETURN(auto token_value, ReadToken(stream));
-
   return Token(token_start.GetTextTo(stream), token_value);
 }
 

--- a/scic/tokenizer/token_readers.cpp
+++ b/scic/tokenizer/token_readers.cpp
@@ -16,6 +16,7 @@
 #include "absl/strings/str_format.h"
 #include "scic/chartype.hpp"
 #include "scic/tokenizer/char_stream.hpp"
+#include "scic/tokenizer/text_contents.hpp"
 #include "scic/tokenizer/token.hpp"
 #include "util/status/status_macros.hpp"
 
@@ -435,6 +436,19 @@ absl::StatusOr<std::optional<Token>> NextToken(CharStream& stream) {
   ASSIGN_OR_RETURN(auto token_value, ReadToken(stream));
 
   return Token(token_start.GetTextTo(stream), token_value);
+}
+
+absl::StatusOr<std::vector<Token>> TokenizeText(TextRange text) {
+  std::vector<Token> tokens;
+  CharStream stream(std::move(text));
+  while (true) {
+    ASSIGN_OR_RETURN(auto token, NextToken(stream));
+    if (!token) {
+      break;
+    }
+    tokens.push_back(*token);
+  }
+  return tokens;
 }
 
 }  // namespace tokenizer

--- a/scic/tokenizer/token_readers.hpp
+++ b/scic/tokenizer/token_readers.hpp
@@ -3,13 +3,17 @@
 
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "absl/status/statusor.h"
 #include "scic/tokenizer/char_stream.hpp"
+#include "scic/tokenizer/text_contents.hpp"
 #include "scic/tokenizer/token.hpp"
 
 namespace tokenizer {
+
 absl::StatusOr<std::optional<Token>> NextToken(CharStream& stream);
+absl::StatusOr<std::vector<Token>> TokenizeText(TextRange text);
 
 // These are generally internal, and are provided for testing.
 absl::StatusOr<int> ReadKey(CharStream& stream);

--- a/scic/tokenizer/token_stream.hpp
+++ b/scic/tokenizer/token_stream.hpp
@@ -22,6 +22,8 @@ class TokenStream {
         std::make_move_iterator(std::end(std::forward<C>(tokens))));
   }
 
+  bool HasNext() const { return !curr_tokens_.empty(); }
+
   std::optional<Token> NextToken() {
     if (curr_tokens_.empty()) {
       return std::nullopt;

--- a/scic/tokenizer/token_stream.hpp
+++ b/scic/tokenizer/token_stream.hpp
@@ -1,0 +1,40 @@
+#ifndef TOKENIZER_TOKEN_STREAM_HPP
+#define TOKENIZER_TOKEN_STREAM_HPP
+
+#include <deque>
+#include <iterator>
+#include <optional>
+#include <utility>
+
+#include "scic/tokenizer/token.hpp"
+
+namespace tokenizer {
+
+class TokenStream {
+ public:
+  void PushToken(Token token) { curr_tokens_.push_front(std::move(token)); }
+
+  template <class C>
+  void PushTokens(C&& tokens) {
+    curr_tokens_.insert(
+        curr_tokens_.begin(),
+        std::make_move_iterator(std::begin(std::forward<C>(tokens))),
+        std::make_move_iterator(std::end(std::forward<C>(tokens))));
+  }
+
+  std::optional<Token> NextToken() {
+    if (curr_tokens_.empty()) {
+      return std::nullopt;
+    }
+    Token token = std::move(curr_tokens_.front());
+    curr_tokens_.pop_front();
+    return token;
+  }
+
+ private:
+  std::deque<Token> curr_tokens_;
+};
+
+}  // namespace tokenizer
+
+#endif


### PR DESCRIPTION
This is an alternate parser for scic, which fully processes a program into S-Expression list trees. This should greatly simplify the parsing logic, while making it possible to do much better error recovery.