### PR TITLE
Extract the ANode code into its own library

### DIFF
--- a/scic/BUILD.bazel
+++ b/scic/BUILD.bazel
@@ -127,13 +127,36 @@ cc_library(
     deps = ["@abseil-cpp//absl/functional:any_invocable"],
 )
 
+cc_library(
+    name = "anode",
+    srcs = [
+        "alist.cpp",
+        "anode.cpp",
+        "optimize.cpp",
+    ],
+    hdrs = [
+        "alist.hpp",
+        "anode.hpp",
+        "optimize.hpp",
+    ],
+    deps = [
+        ":casts",
+        ":common",
+        ":config",
+        ":list",
+        ":listing",
+        ":opcodes",
+        ":output",
+        ":symtypes",
+        ":text",
+        ":varlist",
+        "@abseil-cpp//absl/strings:str_format",
+    ],
+)
+
 cc_binary(
     name = "scic",
     srcs = [
-        "alist.cpp",
-        "alist.hpp",
-        "anode.cpp",
-        "anode.hpp",
         "asm.cpp",
         "asm.hpp",
         "banner.cpp",
@@ -158,8 +181,6 @@ cc_binary(
         "loop.hpp",
         "object.cpp",
         "object.hpp",
-        "optimize.cpp",
-        "optimize.hpp",
         "parse.cpp",
         "parse.hpp",
         "parse_class.cpp",
@@ -196,12 +217,11 @@ cc_binary(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        ":casts",
+        ":anode",
         ":chartype",
         ":common",
         ":config",
         ":input",
-        ":list",
         ":listing",
         ":memtype",
         ":opcodes",

--- a/scic/anode.cpp
+++ b/scic/anode.cpp
@@ -24,7 +24,6 @@
 #include "scic/optimize.hpp"
 #include "scic/output.hpp"
 #include "scic/parse_context.hpp"
-#include "scic/symbol.hpp"
 #include "scic/symtypes.hpp"
 #include "scic/text.hpp"
 #include "scic/varlist.hpp"
@@ -568,21 +567,17 @@ void ANOpOfs::emit(FixupContext* fixup_ctxt, OutputFile* out) {
 // Class ANObjID
 ///////////////////////////////////////////////////
 
-ANObjID::ANObjID(Symbol* s) : ANOpCode(op_lofsa) { sym = s; }
+ANObjID::ANObjID(int lineNum, std::string name)
+    : ANOpCode(op_lofsa), lineNum(lineNum), name(std::move(name)) {}
 
 size_t ANObjID::size() { return WORDSIZE; }
 
 void ANObjID::list(ListingFile* listFile) {
   listFile->ListOp(*offset, op);
-  listFile->ListArg("$%-4x\t(%s)", *target->offset, sym->name());
+  listFile->ListArg("$%-4x\t(%s)", *target->offset, name);
 }
 
 void ANObjID::emit(FixupContext* fixup_ctxt, OutputFile* out) {
-  if (!sym) {
-    Error("Undefined object from line %u: %s", sym->lineNum, sym->name());
-    return;
-  }
-
   out->WriteOp(op);
   fixup_ctxt->AddFixup(*offset + 1);
   out->WriteWord(*target->offset);

--- a/scic/anode.cpp
+++ b/scic/anode.cpp
@@ -18,7 +18,6 @@
 #include "scic/config.hpp"
 #include "scic/error.hpp"
 #include "scic/listing.hpp"
-#include "scic/object.hpp"
 #include "scic/opcodes.hpp"
 #include "scic/optimize.hpp"
 #include "scic/output.hpp"
@@ -180,10 +179,10 @@ void ANText::emit(FixupContext* fixup_ctxt, OutputFile* out) {
 // Class ANObject
 ///////////////////////////////////////////////////
 
-ANObject::ANObject(Object* obj) : obj(obj) {}
+ANObject::ANObject(std::string name) : name(std::move(name)) {}
 
 void ANObject::list(ListingFile* listFile) {
-  listFile->Listing("\nObject: %-20s", obj->name);
+  listFile->Listing("\nObject: %-20s", name);
 }
 
 ///////////////////////////////////////////////////
@@ -224,11 +223,11 @@ void ANProcCode::list(ListingFile* listFile) {
 // Class ANMethCode
 ///////////////////////////////////////////////////
 
-ANMethCode::ANMethCode(std::string name, Object* obj)
-    : ANCodeBlk(std::move(name)), obj(obj) {}
+ANMethCode::ANMethCode(std::string name, std::string obj_name)
+    : ANCodeBlk(std::move(name)), obj_name(std::move(obj_name)) {}
 
 void ANMethCode::list(ListingFile* listFile) {
-  listFile->Listing("\n\nMethod: (%s %s)\n", obj->name, name);
+  listFile->Listing("\n\nMethod: (%s %s)\n", obj_name, name);
   ANCodeBlk::list(listFile);
 }
 

--- a/scic/anode.cpp
+++ b/scic/anode.cpp
@@ -13,10 +13,10 @@
 #include <string_view>
 #include <utility>
 
+#include "absl/strings/str_format.h"
 #include "scic/alist.hpp"
 #include "scic/common.hpp"
 #include "scic/config.hpp"
-#include "scic/error.hpp"
 #include "scic/listing.hpp"
 #include "scic/opcodes.hpp"
 #include "scic/optimize.hpp"
@@ -462,7 +462,7 @@ void ANCall::list(ListingFile* listFile) {
 
 void ANCall::emit(FixupContext* fixup_ctxt, OutputFile* out) {
   if (!target || !target->offset.has_value()) {
-    Error("Undefined procedure: %s", name);
+    throw std::runtime_error(absl::StrFormat("Undefined procedure: %s", name));
     return;
   }
 

--- a/scic/anode.cpp
+++ b/scic/anode.cpp
@@ -14,7 +14,6 @@
 #include <utility>
 
 #include "scic/alist.hpp"
-#include "scic/asm.hpp"
 #include "scic/common.hpp"
 #include "scic/config.hpp"
 #include "scic/error.hpp"
@@ -23,7 +22,6 @@
 #include "scic/opcodes.hpp"
 #include "scic/optimize.hpp"
 #include "scic/output.hpp"
-#include "scic/parse_context.hpp"
 #include "scic/symtypes.hpp"
 #include "scic/text.hpp"
 #include "scic/varlist.hpp"
@@ -226,8 +224,8 @@ void ANProcCode::list(ListingFile* listFile) {
 // Class ANMethCode
 ///////////////////////////////////////////////////
 
-ANMethCode::ANMethCode(std::string name)
-    : ANCodeBlk(std::move(name)), obj(gCurObj) {}
+ANMethCode::ANMethCode(std::string name, Object* obj)
+    : ANCodeBlk(std::move(name)), obj(obj) {}
 
 void ANMethCode::list(ListingFile* listFile) {
   listFile->Listing("\n\nMethod: (%s %s)\n", obj->name, name);

--- a/scic/anode.hpp
+++ b/scic/anode.hpp
@@ -129,7 +129,7 @@ struct ANMethCode : ANCodeBlk
 // ANMethCode is just a listing-specific subclass of ANCodeBlk, which
 // generates "Method" rather than "Procedure" in the listing.
 {
-  ANMethCode(std::string name);
+  ANMethCode(std::string name, Object* obj);
 
   void list(ListingFile* listFile) override;
 

--- a/scic/anode.hpp
+++ b/scic/anode.hpp
@@ -13,7 +13,6 @@
 
 #include "scic/alist.hpp"
 #include "scic/listing.hpp"
-#include "scic/object.hpp"
 
 class OutputFile;
 
@@ -99,11 +98,11 @@ struct ANObject : ANode
 // It generates nothing in the object code file.  The object itself is built
 // up of ANTables containing properties, method dispatch vectors, etc.
 {
-  ANObject(Object* obj);
+  ANObject(std::string name);
 
   void list(ListingFile* listFile) override;
 
-  Object* obj;
+  std::string name;  // name of object
 };
 
 struct ANCodeBlk : ANode
@@ -129,12 +128,11 @@ struct ANMethCode : ANCodeBlk
 // ANMethCode is just a listing-specific subclass of ANCodeBlk, which
 // generates "Method" rather than "Procedure" in the listing.
 {
-  ANMethCode(std::string name, Object* obj);
+  ANMethCode(std::string name, std::string obj_name);
 
   void list(ListingFile* listFile) override;
 
-  Object* obj;  // pointer to symbol of object which this is a
-                // method for
+  std::string obj_name;  // name of object
 };
 
 struct ANProcCode : ANCodeBlk

--- a/scic/anode.hpp
+++ b/scic/anode.hpp
@@ -335,13 +335,14 @@ struct ANObjID : ANOpCode
 // In the interpreter this gets fixed up at load time so that the opcode
 // generates the address of the object in the heap.
 {
-  ANObjID(Symbol* sym);
+  ANObjID(int lineNum, std::string name);
 
   size_t size() override;
   void list(ListingFile* listFile) override;
   void emit(FixupContext*, OutputFile*) override;
 
-  Symbol* sym;
+  int lineNum;
+  std::string name;
   ANode* target;
 };
 

--- a/scic/common.hpp
+++ b/scic/common.hpp
@@ -22,4 +22,6 @@ inline constexpr std::size_t DEFINED = 1;
 using SCIWord = std::int16_t;
 using SCIUWord = std::uint16_t;
 
+inline constexpr int KERNEL = -1;  // Module # of kernel
+
 #endif

--- a/scic/compile.cpp
+++ b/scic/compile.cpp
@@ -373,7 +373,12 @@ static void MakeObjID(AOpList* curList, PNode* pn) {
 
   else {
     Symbol* sym = pn->sym;
-    ANObjID* an = curList->newNode<ANObjID>(sym);
+    if (!sym) {
+      Error("Undefined object from line %u: %s", sym->lineNum, sym->name());
+      return;
+    }
+    ANObjID* an =
+        curList->newNode<ANObjID>(sym->lineNum, std::string(sym->name()));
 
     // If the object is not defined yet, add this node to the list
     // of those waiting for the definition.

--- a/scic/compile.cpp
+++ b/scic/compile.cpp
@@ -946,7 +946,7 @@ static void MakeProc(AList* curList, PNode* pn) {
                       ? (ANCodeBlk*)curList->newNode<ANProcCode>(
                             std::string(pn->sym->name()))
                       : (ANCodeBlk*)curList->newNode<ANMethCode>(
-                            std::string(pn->sym->name()));
+                            std::string(pn->sym->name()), gCurObj);
 
   pn->sym->type = (sym_t)(pn->type == PN_PROC ? S_PROC : S_SELECT);
 

--- a/scic/compile.cpp
+++ b/scic/compile.cpp
@@ -946,7 +946,7 @@ static void MakeProc(AList* curList, PNode* pn) {
                       ? (ANCodeBlk*)curList->newNode<ANProcCode>(
                             std::string(pn->sym->name()))
                       : (ANCodeBlk*)curList->newNode<ANMethCode>(
-                            std::string(pn->sym->name()), gCurObj);
+                            std::string(pn->sym->name()), gCurObj->name);
 
   pn->sym->type = (sym_t)(pn->type == PN_PROC ? S_PROC : S_SELECT);
 
@@ -999,8 +999,8 @@ void MakeObject(Object* theObj) {
 
   {
     // Create the object ID node.
-    ANObject* obj =
-        gSc->heapList->getList()->newNodeBefore<ANObject>(nullptr, theObj);
+    ANObject* obj = gSc->heapList->getList()->newNodeBefore<ANObject>(
+        nullptr, theObj->name);
     theObj->an = obj;
 
     // Create the table of properties.
@@ -1041,7 +1041,7 @@ void MakeObject(Object* theObj) {
   }
 
   // The rest of the object goes into hunk, as it never changes.
-  gSc->hunkList->getList()->newNodeBefore<ANObject>(gCodeStart, theObj);
+  gSc->hunkList->getList()->newNodeBefore<ANObject>(gCodeStart, theObj->name);
 
   // If this a class, add the property dictionary.
   ANObjTable* propDict = gSc->hunkList->getList()->newNodeBefore<ANObjTable>(

--- a/scic/loop.cpp
+++ b/scic/loop.cpp
@@ -3,13 +3,12 @@
 
 #include <cassert>
 
-#include "alist.hpp"
+#include "scic/alist.hpp"
 #include "scic/anode.hpp"
 #include "scic/compile.hpp"
 #include "scic/opcodes.hpp"
 #include "scic/pnode.hpp"
 #include "scic/reference.hpp"
-#include "scic/symbol.hpp"
 
 enum LoopType { LOOP_FOR, LOOP_WHILE, LOOP_REPEAT };
 

--- a/scic/parse_class.cpp
+++ b/scic/parse_class.cpp
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "scic/class.hpp"
+#include "scic/common.hpp"
 #include "scic/error.hpp"
 #include "scic/object.hpp"
 #include "scic/parse.hpp"

--- a/scic/symbol.hpp
+++ b/scic/symbol.hpp
@@ -87,6 +87,4 @@ inline constexpr auto CLOSE_B = ((sym_t)'}');
 inline bool OpenP(sym_t c) { return c == OPEN_P; }
 inline bool CloseP(sym_t c) { return c == CLOSE_P; }
 
-#define KERNEL -1  // Module # of kernel
-
 #endif


### PR DESCRIPTION
The ANode code appears to be the most reusable part of the original SCI Compiler. By extracting it from the rest of the code, we can try to use a new frontend with it